### PR TITLE
Integrate frontend layout with prototype

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,15 @@ services:
     depends_on:
       - mysql
 
+  backend:
+    build: ./backend
+    env_file:
+      - ./backend/.env
+    ports:
+      - "3001:3001"
+    depends_on:
+      - mysql
+
 # #Api de respuestas
 #   api_respuestas:
 #     build: ./API_RESPUESTASESTUDIANTES

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #f9fafb; /* bg-gray-50 */
   --foreground: #171717;
 }
 
@@ -12,12 +12,15 @@
   --font-mono: var(--font-geist-mono);
 }
 
+/* Removemos la preferencia de tema oscuro para mantener el diseño consistente */
+/* 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
   }
 }
+*/
 
 body {
   background: var(--background);

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,9 @@
+'use client';
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navigation from "../components/Navigation";
+import { useEffect, useState } from "react";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -22,12 +25,22 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const [userRole, setUserRole] = useState<'docente' | 'estudiante' | null>(null);
+
+  useEffect(() => {
+    const role = localStorage.getItem('userType');
+    if (role === 'docente' || role === 'estudiante') {
+      setUserRole(role);
+    } else {
+      setUserRole(null);
+    }
+  }, []);
+
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+    <html lang="es">
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <Navigation userRole={userRole} />
+        <main className="min-h-screen bg-gray-50">{children}</main>
       </body>
     </html>
   );

--- a/frontend/app/questions/page.tsx
+++ b/frontend/app/questions/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import QuestionList from '../../components/QuestionList';
+import Link from 'next/link';
+
+export default function QuestionsPage() {
+  return (
+    <div className="min-h-screen p-8 bg-gray-50">
+      <div className="container mx-auto px-4 mb-6">
+        <Link href="/docente" className="inline-block bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold px-6 py-2 rounded-full transition-all mb-4">
+          ← Volver
+        </Link>
+      </div>
+      <QuestionList />
+    </div>
+  );
+} 

--- a/frontend/components/Navigation.tsx
+++ b/frontend/components/Navigation.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface NavigationProps {
+  userRole: 'docente' | 'estudiante' | null;
+}
+
+export default function Navigation({ userRole }: NavigationProps) {
+  const pathname = usePathname();
+
+  return (
+    <nav className="bg-white shadow">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between h-16">
+          <div className="flex">
+            <div className="flex-shrink-0 flex items-center">
+              <Link href="/" className="text-xl font-bold text-gray-800">
+                Sistema de Ensayos
+              </Link>
+            </div>
+            <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
+              <Link
+                href="/"
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  pathname === '/'
+                    ? 'border-blue-500 text-gray-900'
+                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                }`}
+              >
+                Inicio
+              </Link>
+              
+              {userRole === 'docente' && (
+                <Link
+                  href="/questions"
+                  className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                    pathname === '/questions'
+                      ? 'border-blue-500 text-gray-900'
+                      : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                  }`}
+                >
+                  Gestionar Preguntas
+                </Link>
+              )}
+            </div>
+          </div>
+          <div className="hidden sm:ml-6 sm:flex sm:items-center">
+            <Link
+              href="/perfil"
+              className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                pathname === '/perfil'
+                  ? 'border-blue-500 text-gray-900'
+                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+              }`}
+            >
+              Perfil
+            </Link>
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+} 

--- a/frontend/components/QuestionForm.tsx
+++ b/frontend/components/QuestionForm.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { questionsService } from '../services/questionsService';
+
+export interface QuestionFormProps {
+  initialData?: any;
+  onSubmit: (data: any) => void;
+  onCancel: () => void;
+  loading?: boolean;
+}
+
+const SUBJECTS = [
+  'Matemática',
+  'Lenguaje',
+  'Historia',
+  'Ciencias',
+];
+
+const levels = ['Fácil', 'Medio', 'Difícil'];
+
+export default function QuestionForm({ initialData, onSubmit, onCancel, loading }: QuestionFormProps) {
+  const [form, setForm] = useState({
+    subject: '',
+    level: '',
+    statement: '',
+    option_a: '',
+    option_b: '',
+    option_c: '',
+    option_d: '',
+    correct_answer: '',
+  });
+
+  useEffect(() => {
+    if (initialData) {
+      setForm({ ...form, ...initialData });
+    }
+    // eslint-disable-next-line
+  }, [initialData]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Materia</label>
+        <select
+          name="subject"
+          value={form.subject}
+          onChange={handleChange}
+          className="w-full border rounded-lg px-3 py-2 mt-1 bg-white"
+          required
+        >
+          <option value="">Selecciona una materia</option>
+          {SUBJECTS.map((subj) => (
+            <option key={subj} value={subj}>{subj}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Nivel</label>
+        <select
+          name="level"
+          value={form.level}
+          onChange={handleChange}
+          className="w-full border rounded-lg px-3 py-2 mt-1"
+          required
+        >
+          <option value="">Selecciona un nivel</option>
+          <option value="Fácil">Fácil</option>
+          <option value="Medio">Medio</option>
+          <option value="Difícil">Difícil</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Enunciado</label>
+        <textarea
+          name="statement"
+          value={form.statement}
+          onChange={handleChange}
+          className="w-full border rounded-lg px-3 py-2 mt-1"
+          required
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Opción A</label>
+          <input
+            name="option_a"
+            value={form.option_a}
+            onChange={handleChange}
+            className="w-full border rounded-lg px-3 py-2 mt-1"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Opción B</label>
+          <input
+            name="option_b"
+            value={form.option_b}
+            onChange={handleChange}
+            className="w-full border rounded-lg px-3 py-2 mt-1"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Opción C</label>
+          <input
+            name="option_c"
+            value={form.option_c}
+            onChange={handleChange}
+            className="w-full border rounded-lg px-3 py-2 mt-1"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Opción D</label>
+          <input
+            name="option_d"
+            value={form.option_d}
+            onChange={handleChange}
+            className="w-full border rounded-lg px-3 py-2 mt-1"
+            required
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Respuesta Correcta</label>
+        <select
+          name="correct_answer"
+          value={form.correct_answer}
+          onChange={handleChange}
+          className="w-full border rounded-lg px-3 py-2 mt-1"
+          required
+        >
+          <option value="">Selecciona la respuesta</option>
+          <option value="A">A</option>
+          <option value="B">B</option>
+          <option value="C">C</option>
+          <option value="D">D</option>
+        </select>
+      </div>
+      <div className="flex justify-end gap-4 pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 rounded-lg bg-gray-200 hover:bg-gray-300 text-gray-700"
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white"
+        >
+          {loading ? 'Guardando...' : 'Guardar'}
+        </button>
+      </div>
+    </form>
+  );
+} 

--- a/frontend/components/QuestionList.tsx
+++ b/frontend/components/QuestionList.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Question } from '../types/question';
+import QuestionForm from './QuestionForm';
+
+const API_URL = 'http://localhost:8080/questions';
+
+export default function QuestionList() {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editId, setEditId] = useState<number | null>(null);
+  const [formLoading, setFormLoading] = useState(false);
+
+  useEffect(() => {
+    fetchQuestions();
+  }, []);
+
+  const fetchQuestions = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(API_URL, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`Error al obtener preguntas: ${response.status} ${response.statusText}`);
+      }
+      const data = await response.json();
+      setQuestions(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al obtener preguntas');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreate = () => {
+    setEditId(null);
+    setShowCreateForm((prev) => !prev);
+  };
+
+  const handleEdit = (id: number) => {
+    setShowCreateForm(false);
+    setEditId(id);
+  };
+
+  const handleFormSubmit = async (data: any, isEdit: boolean, id?: number) => {
+    setFormLoading(true);
+    try {
+      if (isEdit && id) {
+        // Editar
+        const response = await fetch(`${API_URL}/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        });
+        if (!response.ok) throw new Error('Error al actualizar pregunta');
+        setEditId(null);
+      } else {
+        // Crear
+        const response = await fetch(API_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        });
+        if (!response.ok) throw new Error('Error al crear pregunta');
+        setShowCreateForm(false);
+      }
+      fetchQuestions();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Error al guardar pregunta');
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('¿Estás seguro de que quieres eliminar esta pregunta?')) return;
+    try {
+      const response = await fetch(`${API_URL}/${id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!response.ok) throw new Error('Error al eliminar pregunta');
+      setQuestions(questions.filter(q => q.id !== id));
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al eliminar pregunta');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4">
+        <div className="text-center py-12">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">Cargando preguntas...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4">
+        <div className="bg-red-50 border border-red-200 text-red-700 px-6 py-4 rounded-xl" role="alert">
+          <div className="flex items-center gap-3">
+            <svg className="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <strong className="font-semibold">Error: </strong>
+            <span>{error}</span>
+          </div>
+          <div className="mt-4 pl-9">
+            <p className="text-sm text-red-600">Por favor verifica que:</p>
+            <ul className="list-disc list-inside mt-2 text-sm text-red-600">
+              <li>La API está corriendo en http://localhost:8080</li>
+              <li>No hay problemas de CORS</li>
+              <li>La API está respondiendo correctamente</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4">
+      <div className="flex justify-between items-center mb-8">
+        <h1 className="text-2xl font-semibold text-gray-800">Gestión de Preguntas</h1>
+        <button
+          onClick={handleCreate}
+          className={`inline-flex items-center gap-2 px-4 py-2 rounded-xl transition-colors ${showCreateForm ? 'bg-gray-300 text-gray-700' : 'bg-blue-600 text-white hover:bg-blue-700'}`}
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+          </svg>
+          {showCreateForm ? 'Cancelar' : 'Crear Nueva Pregunta'}
+        </button>
+      </div>
+
+      {/* Formulario de creación */}
+      {showCreateForm && (
+        <div className="mb-8 bg-white rounded-xl shadow-md p-6">
+          <h2 className="text-lg font-semibold mb-4 text-gray-800">Crear Nueva Pregunta</h2>
+          <QuestionForm
+            onSubmit={(data) => handleFormSubmit(data, false)}
+            onCancel={() => setShowCreateForm(false)}
+            loading={formLoading}
+          />
+        </div>
+      )}
+
+      <div className="grid gap-6">
+        {questions.map((question) => (
+          <div key={question.id} className="bg-white p-6 rounded-xl shadow-sm hover:shadow-md transition-shadow mb-2">
+            <div className="flex justify-between items-start mb-4">
+              <div>
+                <h2 className="text-xl font-semibold text-gray-800 mb-2">{question.statement}</h2>
+                <p className="text-gray-600">{question.subject} | {question.level}</p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleEdit(question.id)}
+                  className="inline-flex items-center gap-1 px-3 py-1.5 bg-blue-50 text-blue-600 rounded-lg hover:bg-blue-100 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                  Editar
+                </button>
+                <button
+                  onClick={() => handleDelete(question.id)}
+                  className="inline-flex items-center gap-1 px-3 py-1.5 bg-red-50 text-red-600 rounded-lg hover:bg-red-100 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                  Eliminar
+                </button>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4 mt-4 pt-4 border-t border-gray-100">
+              <div>
+                <p className="text-sm font-medium text-gray-500">Opciones</p>
+                <ul className="text-gray-800">
+                  <li>A: {question.option_a}</li>
+                  <li>B: {question.option_b}</li>
+                  <li>C: {question.option_c}</li>
+                  <li>D: {question.option_d}</li>
+                </ul>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-500">Respuesta Correcta</p>
+                <p className="text-gray-800">{question.correct_answer}</p>
+              </div>
+            </div>
+            {/* Formulario de edición embebido */}
+            {editId === question.id && (
+              <div className="mt-8 bg-gray-50 rounded-xl shadow-inner p-6">
+                <h2 className="text-lg font-semibold mb-4 text-gray-800">Editar Pregunta</h2>
+                <QuestionForm
+                  initialData={question}
+                  onSubmit={(data) => handleFormSubmit(data, true, question.id)}
+                  onCancel={() => setEditId(null)}
+                  loading={formLoading}
+                />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+} 

--- a/frontend/types/question.ts
+++ b/frontend/types/question.ts
@@ -1,0 +1,11 @@
+export interface Question {
+  id: number;
+  subject: string;
+  level: string;
+  statement: string;
+  option_a: string;
+  option_b: string;
+  option_c: string;
+  option_d: string;
+  correct_answer: string;
+} 


### PR DESCRIPTION
## Summary
- style Next.js frontend using prototype layout
- add reusable navigation component
- expose prototype question pages
- run backend via docker-compose

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1845619083249fea84f46093bdaa